### PR TITLE
ひらがなの最初の文字

### DIFF
--- a/exercises/ownership/src/main.rs
+++ b/exercises/ownership/src/main.rs
@@ -31,7 +31,7 @@ fn remove_hiragana(text: String) -> String {
     */
     let result = String::new();
     for c in text.chars() {
-        if c < 'あ' || 'ん' < c {
+        if c < 'ぁ' || 'ん' < c {
             result.push(c);
         };
     }


### PR DESCRIPTION
[ひらがなの最初の文字](http://www.asahi-net.or.jp/~ax2s-kmtn/ref/unicode/u3040.html)は `あ` ではなく `ぁ` であることに気付いたので、ちょっと細かいですがPRを出そうと思います。